### PR TITLE
HOTFIX 0.6.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
     <groupId>org.rippleosi</groupId>
     <artifactId>ripple</artifactId>
-    <version>0.6.0.0</version>
+    <version>0.7.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Ripple OSI</name>
@@ -29,7 +29,7 @@
 
     <scm>
         <connection>scm:git:https://github.com/RippleOSI/Org-Ripple-core.git</connection>
-        <tag>v0.6.0.0</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -15,14 +15,13 @@
 ~      limitations under the License.
 ~
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>org.rippleosi</groupId>
     <artifactId>ripple</artifactId>
-    <version>0.6.0.0-SNAPSHOT</version>
+    <version>0.6.0.0</version>
     <packaging>pom</packaging>
 
     <name>Ripple OSI</name>
@@ -30,7 +29,7 @@
 
     <scm>
         <connection>scm:git:https://github.com/RippleOSI/Org-Ripple-core.git</connection>
-        <tag>HEAD</tag>
+        <tag>v0.6.0.0</tag>
     </scm>
 
     <distributionManagement>

--- a/ripple-api/pom.xml
+++ b/ripple-api/pom.xml
@@ -11,54 +11,12 @@
     <dependencies>
         <dependency>
             <groupId>org.rippleosi</groupId>
-            <artifactId>ripple-audit-example</artifactId>
-            <scope>runtime</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.rippleosi</groupId>
             <artifactId>ripple-core</artifactId>
         </dependency>
 
         <dependency>
             <groupId>org.rippleosi</groupId>
-            <artifactId>ripple-database</artifactId>
-            <scope>runtime</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.rippleosi</groupId>
-            <artifactId>ripple-dicom</artifactId>
-            <scope>runtime</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.rippleosi</groupId>
-            <artifactId>ripple-ethercis</artifactId>
-            <scope>runtime</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.rippleosi</groupId>
-            <artifactId>ripple-openehr</artifactId>
-            <scope>runtime</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.rippleosi</groupId>
             <artifactId>ripple-security</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.rippleosi</groupId>
-            <artifactId>ripple-terminology-example</artifactId>
-            <scope>runtime</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.rippleosi</groupId>
-            <artifactId>ripple-vista</artifactId>
-            <scope>runtime</scope>
         </dependency>
         
         <dependency>

--- a/ripple-api/pom.xml
+++ b/ripple-api/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.rippleosi</groupId>
         <artifactId>ripple</artifactId>
-        <version>0.6.0.0-SNAPSHOT</version>
+        <version>0.6.0.0</version>
     </parent>
     <artifactId>ripple-api</artifactId>
 

--- a/ripple-api/pom.xml
+++ b/ripple-api/pom.xml
@@ -191,4 +191,13 @@
         </dependency>
 
     </dependencies>
+	
+    <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
+    </build>
 </project>

--- a/ripple-api/pom.xml
+++ b/ripple-api/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.rippleosi</groupId>
         <artifactId>ripple</artifactId>
-        <version>0.6.0.0</version>
+        <version>0.7.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>ripple-api</artifactId>
 

--- a/ripple-api/src/main/java/org/rippleosi/config/swagger/SwaggerConfig.java
+++ b/ripple-api/src/main/java/org/rippleosi/config/swagger/SwaggerConfig.java
@@ -15,8 +15,10 @@
  */
 package org.rippleosi.config.swagger;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.PropertySource;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 import springfox.documentation.builders.PathSelectors;
 import springfox.documentation.builders.RequestHandlerSelectors;
@@ -30,8 +32,12 @@ import springfox.documentation.swagger2.annotations.EnableSwagger2;
 @Configuration
 @EnableWebMvc
 @EnableSwagger2
+@PropertySource("classpath:app.properties")
 public class SwaggerConfig {
 
+    @Value("${app.version}")
+    private String appVersion;
+    
     @Bean
     public Docket api() {
         return new Docket(DocumentationType.SWAGGER_2)
@@ -46,7 +52,7 @@ public class SwaggerConfig {
     private ApiInfo apiInfo() {
         return new ApiInfo("Ripple OSI Demonstrator REST API",
                            "The Ripple OSI Demonstrator API.",
-                           "0.6.0.0-SNAPSHOT",
+                           appVersion,
                            "",
                            "",
                            "Apache License v2",

--- a/ripple-api/src/main/resources/app.properties
+++ b/ripple-api/src/main/resources/app.properties
@@ -1,0 +1,1 @@
+app.version=${project.version}

--- a/ripple-audit-example/pom.xml
+++ b/ripple-audit-example/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.rippleosi</groupId>
         <artifactId>ripple</artifactId>
-        <version>0.6.0.0</version>
+        <version>0.7.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>ripple-audit-example</artifactId>

--- a/ripple-audit-example/pom.xml
+++ b/ripple-audit-example/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.rippleosi</groupId>
         <artifactId>ripple</artifactId>
-        <version>0.6.0.0-SNAPSHOT</version>
+        <version>0.6.0.0</version>
     </parent>
 
     <artifactId>ripple-audit-example</artifactId>

--- a/ripple-core/pom.xml
+++ b/ripple-core/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.rippleosi</groupId>
         <artifactId>ripple</artifactId>
-        <version>0.6.0.0</version>
+        <version>0.7.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>ripple-core</artifactId>

--- a/ripple-core/pom.xml
+++ b/ripple-core/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.rippleosi</groupId>
         <artifactId>ripple</artifactId>
-        <version>0.6.0.0-SNAPSHOT</version>
+        <version>0.6.0.0</version>
     </parent>
 
     <artifactId>ripple-core</artifactId>

--- a/ripple-database/pom.xml
+++ b/ripple-database/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.rippleosi</groupId>
         <artifactId>ripple</artifactId>
-        <version>0.6.0.0-SNAPSHOT</version>
+        <version>0.6.0.0</version>
     </parent>
 
     <artifactId>ripple-database</artifactId>

--- a/ripple-database/pom.xml
+++ b/ripple-database/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.rippleosi</groupId>
         <artifactId>ripple</artifactId>
-        <version>0.6.0.0</version>
+        <version>0.7.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>ripple-database</artifactId>

--- a/ripple-dicom/pom.xml
+++ b/ripple-dicom/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>ripple</artifactId>
         <groupId>org.rippleosi</groupId>
-        <version>0.6.0.0-SNAPSHOT</version>
+        <version>0.6.0.0</version>
     </parent>
 
     <artifactId>ripple-dicom</artifactId>

--- a/ripple-dicom/pom.xml
+++ b/ripple-dicom/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>ripple</artifactId>
         <groupId>org.rippleosi</groupId>
-        <version>0.6.0.0</version>
+        <version>0.7.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>ripple-dicom</artifactId>

--- a/ripple-ethercis/pom.xml
+++ b/ripple-ethercis/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>ripple</artifactId>
         <groupId>org.rippleosi</groupId>
-        <version>0.6.0.0-SNAPSHOT</version>
+        <version>0.6.0.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/ripple-ethercis/pom.xml
+++ b/ripple-ethercis/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>ripple</artifactId>
         <groupId>org.rippleosi</groupId>
-        <version>0.6.0.0</version>
+        <version>0.7.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/ripple-openehr/pom.xml
+++ b/ripple-openehr/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.rippleosi</groupId>
         <artifactId>ripple</artifactId>
-        <version>0.6.0.0-SNAPSHOT</version>
+        <version>0.6.0.0</version>
     </parent>
 
     <artifactId>ripple-openehr</artifactId>

--- a/ripple-openehr/pom.xml
+++ b/ripple-openehr/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.rippleosi</groupId>
         <artifactId>ripple</artifactId>
-        <version>0.6.0.0</version>
+        <version>0.7.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>ripple-openehr</artifactId>

--- a/ripple-packaging/pom.xml
+++ b/ripple-packaging/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.rippleosi</groupId>
         <artifactId>ripple</artifactId>
-        <version>0.6.0.0</version>
+        <version>0.7.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>ripple-packaging</artifactId>

--- a/ripple-packaging/pom.xml
+++ b/ripple-packaging/pom.xml
@@ -30,7 +30,49 @@
     <dependencies>
         <dependency>
             <groupId>org.rippleosi</groupId>
+            <artifactId>ripple-audit-example</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+		
+        <dependency>
+            <groupId>org.rippleosi</groupId>
             <artifactId>ripple-api</artifactId>
+        </dependency>
+		
+        <dependency>
+            <groupId>org.rippleosi</groupId>
+            <artifactId>ripple-database</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.rippleosi</groupId>
+            <artifactId>ripple-dicom</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.rippleosi</groupId>
+            <artifactId>ripple-ethercis</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.rippleosi</groupId>
+            <artifactId>ripple-openehr</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.rippleosi</groupId>
+            <artifactId>ripple-terminology-example</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.rippleosi</groupId>
+            <artifactId>ripple-vista</artifactId>
+            <scope>runtime</scope>
         </dependency>
 		
         <dependency>
@@ -132,10 +174,6 @@
             <artifactId>spring-webmvc</artifactId>
         </dependency>
     </dependencies>
-
-    <build>
-        <finalName>ripple-ui</finalName>
-    </build>
 
     <profiles>
         <profile>

--- a/ripple-packaging/pom.xml
+++ b/ripple-packaging/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.rippleosi</groupId>
         <artifactId>ripple</artifactId>
-        <version>0.6.0.0-SNAPSHOT</version>
+        <version>0.6.0.0</version>
     </parent>
 
     <artifactId>ripple-packaging</artifactId>

--- a/ripple-security/pom.xml
+++ b/ripple-security/pom.xml
@@ -1,14 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
         <groupId>org.rippleosi</groupId>
         <artifactId>ripple</artifactId>
-        <version>0.6.0.0-SNAPSHOT</version>
+        <version>0.6.0.0</version>
     </parent>
 
     <artifactId>ripple-security</artifactId>

--- a/ripple-security/pom.xml
+++ b/ripple-security/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.rippleosi</groupId>
         <artifactId>ripple</artifactId>
-        <version>0.6.0.0</version>
+        <version>0.7.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>ripple-security</artifactId>

--- a/ripple-terminology-example/pom.xml
+++ b/ripple-terminology-example/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>ripple</artifactId>
         <groupId>org.rippleosi</groupId>
-        <version>0.6.0.0-SNAPSHOT</version>
+        <version>0.6.0.0</version>
     </parent>
 
     <artifactId>ripple-terminology-example</artifactId>

--- a/ripple-terminology-example/pom.xml
+++ b/ripple-terminology-example/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>ripple</artifactId>
         <groupId>org.rippleosi</groupId>
-        <version>0.6.0.0</version>
+        <version>0.7.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>ripple-terminology-example</artifactId>

--- a/ripple-vista/pom.xml
+++ b/ripple-vista/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>ripple</artifactId>
         <groupId>org.rippleosi</groupId>
-        <version>0.6.0.0</version>
+        <version>0.7.0.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/ripple-vista/pom.xml
+++ b/ripple-vista/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>ripple</artifactId>
         <groupId>org.rippleosi</groupId>
-        <version>0.6.0.0-SNAPSHOT</version>
+        <version>0.6.0.0</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>


### PR DESCRIPTION
Removed unnecessary default included dependencies so that only the 3
core libraries are included when linking against ripple-api